### PR TITLE
rviz configuration file startup issue

### DIFF
--- a/lawn_tractor_sim/launch/lawn_tractor_sim.launch
+++ b/lawn_tractor_sim/launch/lawn_tractor_sim.launch
@@ -59,7 +59,7 @@
 
 <!-- ****** RVIZ ***** -->
 <node name="tractor_viz" pkg="rviz" type="rviz" output="screen"
-     args="$(find lawn_tractor_sim)/rviz/tractor_viz.rviz">
+     args="-d $(find lawn_tractor_sim)/rviz/tractor_viz.rviz">
 </node>
 
 <!-- ****** Markers ***** -->


### PR DESCRIPTION
        Added "-d" to the args for the rviz node. This obviates
        manually loading the lawn tractor simulation rviz
        configuration file.